### PR TITLE
Flexible Repo

### DIFF
--- a/lib/railjet.rb
+++ b/lib/railjet.rb
@@ -44,5 +44,6 @@ require "railjet/repository/registry"
 require "railjet/repository"
 require "railjet/repository/active_record"
 require "railjet/repository/cupido"
+require "railjet/repository/redis"
 
 require "railjet/railtie" if defined?(Rails)

--- a/lib/railjet.rb
+++ b/lib/railjet.rb
@@ -42,5 +42,7 @@ require "railjet/use_case"
 
 require "railjet/repository/registry"
 require "railjet/repository"
+require "railjet/repository/active_record"
+require "railjet/repository/cupido"
 
 require "railjet/railtie" if defined?(Rails)

--- a/lib/railjet/repository/active_record.rb
+++ b/lib/railjet/repository/active_record.rb
@@ -3,6 +3,8 @@ require_relative "generic"
 module Railjet
   module Repository
     class ActiveRecord < Generic
+      self.type = :record
+      
       def all
         record.all
       end

--- a/lib/railjet/repository/active_record.rb
+++ b/lib/railjet/repository/active_record.rb
@@ -1,17 +1,8 @@
+require_relative "generic"
+
 module Railjet
   module Repository
-    module ActiveRecord
-      extend ::ActiveSupport::Concern
-
-      included do
-        attr_reader :registry, :record
-      end
-
-      def initialize(registry, record = nil)
-        @registry = registry
-        @record   = record
-      end
-
+    class ActiveRecord < Generic
       def all
         record.all
       end

--- a/lib/railjet/repository/cupido.rb
+++ b/lib/railjet/repository/cupido.rb
@@ -1,17 +1,8 @@
+require_relative "generic"
+
 module Railjet
   module Repository
-    module Cupido
-      extend ::ActiveSupport::Concern
-
-      included do
-        attr_reader :registry, :cupido
-      end
-
-      def initialize(registry, cupido = nil)
-        @registry = registry
-        @cupido   = cupido
-      end
-
+    class Cupido < Generic
       def build(args = {})
         cupido.new(args)
       end

--- a/lib/railjet/repository/cupido.rb
+++ b/lib/railjet/repository/cupido.rb
@@ -3,6 +3,8 @@ require_relative "generic"
 module Railjet
   module Repository
     class Cupido < Generic
+      self.type = :cupido
+
       def build(args = {})
         cupido.new(args)
       end

--- a/lib/railjet/repository/generic.rb
+++ b/lib/railjet/repository/generic.rb
@@ -1,0 +1,45 @@
+module Railjet
+  module Repository
+    class Generic < Module
+      def self.[](**kwargs)
+        type, dao = kwargs.first
+        new(type, dao)
+      end
+
+      def initialize(type, dao)
+        @type, @dao = type, dao
+      end
+
+      def included(klass)
+        define_dao_accessor(@type, @dao)
+        define_type_accessor(klass, @type)
+        define_initializer(klass)
+      end
+
+      private
+
+      def define_dao_accessor(type, dao)
+        define_method type do
+          @dao ||= dao.constantize
+        end
+      end
+
+      def define_type_accessor(klass, type)
+        klass.define_singleton_method(:type) do
+          type
+        end
+      end
+
+      def define_initializer(klass)
+        klass.class_eval do
+          attr_reader :registry
+
+          def initialize(registry, dao: nil)
+            @registry = registry
+            @dao      = dao
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/railjet/repository/generic.rb
+++ b/lib/railjet/repository/generic.rb
@@ -1,13 +1,21 @@
 module Railjet
   module Repository
     class Generic < Module
-      def self.[](**kwargs)
-        type, dao = kwargs.first
-        new(type, dao)
+      class << self
+        def [](dao)
+          new(dao)
+        end
+
+        attr_accessor :type
       end
 
-      def initialize(type, dao)
-        @type, @dao = type, dao
+      def self.[](dao)
+        new(dao)
+      end
+
+      def initialize(dao)
+        @dao  = dao
+        @type = self.class.type
       end
 
       def included(klass)

--- a/lib/railjet/repository/redis.rb
+++ b/lib/railjet/repository/redis.rb
@@ -3,6 +3,8 @@ require_relative "generic"
 module Railjet
   module Repository
     class Redis < Generic
+      self.type = :redis
+
       def get(key)
         redis.get(key)
       end

--- a/lib/railjet/repository/redis.rb
+++ b/lib/railjet/repository/redis.rb
@@ -1,0 +1,27 @@
+require_relative "generic"
+
+module Railjet
+  module Repository
+    class Redis < Generic
+      def get(key)
+        redis.get(key)
+      end
+
+      def set(key, val)
+        redis.set(key, val)
+      end
+
+      def exists?(key)
+        redis.exists(key)
+      end
+
+      def transaction(&block)
+        redis.multi(&block)
+      end
+
+      def pipeline(&block)
+        redis.pipelined(&block)
+      end
+    end
+  end
+end

--- a/lib/railjet/repository/registry.rb
+++ b/lib/railjet/repository/registry.rb
@@ -9,8 +9,8 @@ module Railjet
         @initialized_repositories = {}
       end
 
-      def register(name, repository, **kwargs)
-        add_to_registry(name, repository, kwargs)
+      def register(name, repository)
+        add_to_registry(name, repository)
         define_accessor(name)
       end
 
@@ -36,12 +36,9 @@ module Railjet
         @registry_module          = nil
       end
 
-      def add_to_registry(name, repository, args = {})
+      def add_to_registry(name, repository)
         initialized_repositories[name] = nil
-        repositories[name] = {
-          repository: repository,
-          args:       args
-        }
+        repositories[name]             = repository
       end
 
       def get_from_registry(name)
@@ -49,13 +46,7 @@ module Railjet
       end
 
       def initialize_repo(name)
-        initialized_repositories[name] ||= begin
-          repo  = get_from_registry(name)
-          klass = repo[:repository]
-          args  = repo[:args]
-
-          klass.new(self, **args)
-        end
+        initialized_repositories[name] ||= get_from_registry(name).new(self)
       end
 
       def define_accessor(name)

--- a/spec/railjet/integration/repository_spec.rb
+++ b/spec/railjet/integration/repository_spec.rb
@@ -21,7 +21,7 @@ describe "Repository & Registry" do
     delegate :persist,        to: :cupido
 
     class ActiveRecordRepository
-      include Railjet::Repository::ActiveRecord
+      include Railjet::Repository::ActiveRecord[record: 'DummyUserRecord']
 
       def all_with_tasks
         record.all.map do |user|
@@ -32,7 +32,7 @@ describe "Repository & Registry" do
     end
 
     class CupidoRepository
-      include Railjet::Repository::Cupido
+      include Railjet::Repository::Cupido[cupido: 'DummyUserCupido']
 
       def persist(user)
         if registry.respond_to?(:settings) && registry.settings.call_cupido
@@ -43,22 +43,16 @@ describe "Repository & Registry" do
   end
 
   class DummyTaskRepository
-    include Railjet::Repository
+    include Railjet::Repository::ActiveRecord[record: 'DummyTaskRecord']
 
-    delegate :find_for_user, to: :record
-
-    class ActiveRecordRepository
-      include Railjet::Repository::ActiveRecord
-
-      def find_for_user(user)
-        record.where(user_id: user.id)
-      end
+    def find_for_user(user)
+      record.where(user_id: user.id)
     end
   end
 
   before do
-    registry.register(:user, DummyUserRepository, record: DummyUserRecord, cupido: DummyUserCupido)
-    registry.register(:task, DummyTaskRepository, record: DummyTaskRecord)
+    registry.register(:user, DummyUserRepository)
+    registry.register(:task, DummyTaskRepository)
   end
 
   describe "calling another repo" do

--- a/spec/railjet/integration/repository_spec.rb
+++ b/spec/railjet/integration/repository_spec.rb
@@ -21,7 +21,7 @@ describe "Repository & Registry" do
     delegate :persist,        to: :cupido
 
     class ActiveRecordRepository
-      include Railjet::Repository::ActiveRecord[record: 'DummyUserRecord']
+      include Railjet::Repository::ActiveRecord['DummyUserRecord']
 
       def all_with_tasks
         record.all.map do |user|
@@ -32,7 +32,7 @@ describe "Repository & Registry" do
     end
 
     class CupidoRepository
-      include Railjet::Repository::Cupido[cupido: 'DummyUserCupido']
+      include Railjet::Repository::Cupido['DummyUserCupido']
 
       def persist(user)
         if registry.respond_to?(:settings) && registry.settings.call_cupido
@@ -43,7 +43,7 @@ describe "Repository & Registry" do
   end
 
   class DummyTaskRepository
-    include Railjet::Repository::ActiveRecord[record: 'DummyTaskRecord']
+    include Railjet::Repository::ActiveRecord['DummyTaskRecord']
 
     def find_for_user(user)
       record.where(user_id: user.id)

--- a/spec/railjet/registry_spec.rb
+++ b/spec/railjet/registry_spec.rb
@@ -3,16 +3,13 @@ require "railjet/repository/registry"
 describe Railjet::Repository::Registry do
   let(:app_registry) { Class.new(described_class).new }
 
-  let(:query)  { double('UserRecord') }
-  let(:cupido) { double('Cupido::User') }
-
   class DummyRepository
     def initialize(registry, **kwargs)
     end
   end
 
   before do
-    app_registry.register(:user, DummyRepository, query: query, cupido: cupido)
+    app_registry.register(:user, DummyRepository)
   end
 
   describe "#register" do
@@ -21,7 +18,7 @@ describe Railjet::Repository::Registry do
     end
 
     it "initializes repository with given models" do
-      expect(DummyRepository).to receive(:new).with(app_registry, query: query, cupido: cupido)
+      expect(DummyRepository).to receive(:new).with(app_registry)
       app_registry.users
     end
   end

--- a/spec/railjet/repository_spec.rb
+++ b/spec/railjet/repository_spec.rb
@@ -3,11 +3,9 @@ require "railjet/repository"
 describe Railjet::Repository do
   let(:registry) { double }
 
-  class DummyRecord
-  end
-
-  class DummyCupido
-  end
+  DummyRecord = Class.new
+  DummyCupido = Class.new
+  DummyRedis  = Class.new
 
   class DummyOneRepository
     include Railjet::Repository::Cupido[cupido: 'DummyCupido']
@@ -23,6 +21,10 @@ describe Railjet::Repository do
     class ActiveRecordRepository
       include Railjet::Repository::ActiveRecord[record: 'DummyRecord']
     end
+
+    class RedisRepository
+      include Railjet::Repository::Redis[redis: 'DummyRedis']
+    end
   end
 
   describe "#new" do
@@ -35,11 +37,12 @@ describe Railjet::Repository do
       end
     end
 
-    context "with two DAO" do
+    context "with multiple DAO" do
       subject(:repo) { DummyTwoRepository.new(registry) }
 
       let(:record_repo) { repo.send(:record) }
       let(:cupido_repo) { repo.send(:cupido) }
+      let(:redis_repo)  { repo.send(:redis)  }
 
       it "creates accessor for record" do
         expect(record_repo).to be_instance_of DummyTwoRepository::ActiveRecordRepository
@@ -49,6 +52,11 @@ describe Railjet::Repository do
       it "creates accessor for cupido" do
         expect(cupido_repo).to be_instance_of DummyTwoRepository::CupidoRepository
         expect(cupido_repo.cupido).to eq DummyCupido
+      end
+
+      it "creates accessor for redis" do
+        expect(redis_repo).to be_instance_of DummyTwoRepository::RedisRepository
+        expect(redis_repo.redis).to eq DummyRedis
       end
     end
   end

--- a/spec/railjet/repository_spec.rb
+++ b/spec/railjet/repository_spec.rb
@@ -8,22 +8,22 @@ describe Railjet::Repository do
   DummyRedis  = Class.new
 
   class DummyOneRepository
-    include Railjet::Repository::Cupido[cupido: 'DummyCupido']
+    include Railjet::Repository::Cupido['DummyCupido']
   end
 
   class DummyTwoRepository
     include Railjet::Repository
 
     class CupidoRepository
-      include Railjet::Repository::Cupido[cupido: 'DummyCupido']
+      include Railjet::Repository::Cupido['DummyCupido']
     end
 
     class ActiveRecordRepository
-      include Railjet::Repository::ActiveRecord[record: 'DummyRecord']
+      include Railjet::Repository::ActiveRecord['DummyRecord']
     end
 
     class RedisRepository
-      include Railjet::Repository::Redis[redis: 'DummyRedis']
+      include Railjet::Repository::Redis['DummyRedis']
     end
   end
 

--- a/spec/railjet/repository_spec.rb
+++ b/spec/railjet/repository_spec.rb
@@ -2,86 +2,53 @@ require "railjet/repository"
 
 describe Railjet::Repository do
   let(:registry) { double }
-  let(:record)   { double('UserRecord') }
-  let(:cupido)   { double('Cupido::User') }
+
+  class DummyRecord
+  end
+
+  class DummyCupido
+  end
 
   class DummyOneRepository
-    include Railjet::Repository
-
-    class CupidoRepository
-      include Railjet::Repository::Cupido
-    end
+    include Railjet::Repository::Cupido[cupido: 'DummyCupido']
   end
 
   class DummyTwoRepository
     include Railjet::Repository
 
     class CupidoRepository
-      include Railjet::Repository::Cupido
+      include Railjet::Repository::Cupido[cupido: 'DummyCupido']
     end
 
     class ActiveRecordRepository
-      include Railjet::Repository::ActiveRecord
-    end
-  end
-
-  class AnotherDummyRepository
-    include Railjet::Repository
-
-    def foo
-      record.foo
-    end
-
-    private
-
-    def record
-      @record ||= FooRepository.new(super)
-    end
-
-    class FooRepository < Struct.new(:record)
-      def foo
-        "Bar"
-      end
+      include Railjet::Repository::ActiveRecord[record: 'DummyRecord']
     end
   end
 
   describe "#new" do
     context "with one DAO" do
-      subject(:repo)    { DummyOneRepository.new(registry, cupido: cupido) }
+      subject(:repo)    { DummyOneRepository.new(registry) }
       let(:cupido_repo) { repo.send(:cupido) }
 
-      it "creates single accessor" do
-        expect(cupido_repo).to be_instance_of DummyOneRepository::CupidoRepository
-        expect(cupido_repo.cupido).to eq cupido
-      end
-
-      it "does not create another accessor" do
-        expect(repo.send(:record)).to be_nil
+      it "creates accessor for DAO" do
+        expect(repo.cupido).to be DummyCupido
       end
     end
 
     context "with two DAO" do
-      subject(:repo) { DummyTwoRepository.new(registry, record: record, cupido: cupido) }
+      subject(:repo) { DummyTwoRepository.new(registry) }
 
       let(:record_repo) { repo.send(:record) }
       let(:cupido_repo) { repo.send(:cupido) }
 
       it "creates accessor for record" do
         expect(record_repo).to be_instance_of DummyTwoRepository::ActiveRecordRepository
-        expect(record_repo.record).to eq record
+        expect(record_repo.record).to eq DummyRecord
       end
 
       it "creates accessor for cupido" do
         expect(cupido_repo).to be_instance_of DummyTwoRepository::CupidoRepository
-        expect(cupido_repo.cupido).to eq cupido
-      end
-    end
-
-    describe "overriding accessors" do
-      subject(:repo) { AnotherDummyRepository.new(registry, record: record) }
-
-      it "works with super" do
-        expect(repo.foo).to eq "Bar"
+        expect(cupido_repo.cupido).to eq DummyCupido
       end
     end
   end


### PR DESCRIPTION
Issue #22 

### API

```ruby
registry = Railjet::Repository::Registry.new
registry.register(:event,          EventRepository)
registry.register(:unavailability, UnavailabilityRepository)

class EventRepository
  include Railjet::Repository
  
  delegate :some_method,        to: :record
  delegate :other_method,       to: :cupido
  delegate :yet_another_method, to: :redis

  class ActiveRecordRepository
    include Railjet::Repository::ActiveRecord['Calendar::Record::Event']
    
    def some_method
    end
  end
  
  class CupidoRepository
    include Railjet::Repository::Cupido["Cupido::AgendaOccurrence"]
    
    def other_method
    end
  end

  class RedisRepository
    include Railjet::Repository::Redis["RedisConnection"]

    def yet_another_method
    end
  end
end

class UnavailabilityRepository
  include Railjet::Repository::ActiveRecord["Calendar::Record::Unavailability"]
  
  def some_method
  end
end
```