### PR TITLE
Meaningful exceptions

### DIFF
--- a/lib/railjet.rb
+++ b/lib/railjet.rb
@@ -21,6 +21,10 @@ module Railjet
     def error_messages
       errors.try(:messages)
     end
+
+    def to_s
+      error_messages
+    end
   end
 
   FormError   = Class.new(ValidationError)

--- a/lib/railjet/form.rb
+++ b/lib/railjet/form.rb
@@ -3,8 +3,12 @@ module Railjet
     extend  ::ActiveSupport::Concern
     include Railjet::Validator
 
+    included do
+      const_set(:Error, Class.new(Railjet::FormError))
+    end
+
     def validate!
-      valid? || (raise Railjet::FormError.new(errors) )
+      valid? || (raise self.class::Error.new(errors))
     end
   end
 end

--- a/lib/railjet/form.rb
+++ b/lib/railjet/form.rb
@@ -6,9 +6,5 @@ module Railjet
     included do
       const_set(:Error, Class.new(Railjet::FormError))
     end
-
-    def validate!
-      valid? || (raise self.class::Error.new(errors))
-    end
   end
 end

--- a/lib/railjet/policy.rb
+++ b/lib/railjet/policy.rb
@@ -3,6 +3,11 @@ module Railjet
     extend  ::ActiveSupport::Concern
     include Railjet::Validator
 
+    included do
+      const_set(:Error, Class.new(Railjet::PolicyError))
+    end
+
+
     attr_reader :context, :object
 
     def initialize(context, object)
@@ -10,7 +15,7 @@ module Railjet
     end
 
     def validate!
-      valid? || (raise Railjet::PolicyError.new(errors) )
+      valid? || (raise self.class::Error.new(errors))
     end
 
     module ClassMethods

--- a/lib/railjet/policy.rb
+++ b/lib/railjet/policy.rb
@@ -7,16 +7,11 @@ module Railjet
       const_set(:Error, Class.new(Railjet::PolicyError))
     end
 
-
-    attr_reader :context, :object
-
     def initialize(context, object)
       @context, @object = context, object
     end
-
-    def validate!
-      valid? || (raise self.class::Error.new(errors))
-    end
+    
+    attr_reader :context, :object
 
     module ClassMethods
       def context(*context_members)

--- a/lib/railjet/validator.rb
+++ b/lib/railjet/validator.rb
@@ -9,7 +9,7 @@ module Railjet
     end
 
     def validate!
-      raise NotImplementedError
+      valid? || (raise self.class::Error.new(errors))
     end
   end
 end

--- a/spec/railjet/form_spec.rb
+++ b/spec/railjet/form_spec.rb
@@ -25,6 +25,10 @@ describe Railjet::Form do
           expect(e.errors["name"]).to include /can't be blank/
         end
       end
+
+      it "raises custom exception" do
+        expect { form.validate! }.to raise_exception(DummyForm::Error)
+      end
     end
   end
   

--- a/spec/railjet/policy_spec.rb
+++ b/spec/railjet/policy_spec.rb
@@ -32,6 +32,11 @@ describe Railjet::Policy do
         expect(e.errors[:base]).to include /deadline exceeded/
       end
     end
+
+    it "raises custom exception" do
+      expect { policy.validate! }.to raise_exception(DummyBeforeDeadlinePolicy::Error)
+      binding.pry
+    end
   end
 
   context "valid" do

--- a/spec/railjet/policy_spec.rb
+++ b/spec/railjet/policy_spec.rb
@@ -35,7 +35,6 @@ describe Railjet::Policy do
 
     it "raises custom exception" do
       expect { policy.validate! }.to raise_exception(DummyBeforeDeadlinePolicy::Error)
-      binding.pry
     end
   end
 


### PR DESCRIPTION
https://github.com/nedap/railjet/issues/26

> I have a policy that does two checks, but depending on which one fails, I would like to handle the Policy error differently.
> 
> What is the cleanest way to implement that in your opininion?

Let's raise an Error obj scoped to the Form/Policy instead of global FormError/PolicyError exception