### PR TITLE
Fix Repository bug

### DIFF
--- a/lib/railjet/repository/active_record.rb
+++ b/lib/railjet/repository/active_record.rb
@@ -4,43 +4,45 @@ module Railjet
   module Repository
     class ActiveRecord < Generic
       self.type = :record
-      
-      def all
-        record.all
-      end
 
-      def find_by_ids(ids)
-        record.where(id: ids)
-      end
-
-      def build(args = {}, &block)
-        record.new(args, &block)
-      end
-
-      def duplicate(object, args = {})
-        object.dup.tap do |new_object|
-          new_object.assign_attributes(args) if args.present?
-          yield(new_object)                  if block_given?
+      module RepositoryMethods
+        def all
+          record.all
         end
-      end
 
-      def persist(object)
-        object.save!
-      end
+        def find_by_ids(ids)
+          record.where(id: ids)
+        end
 
-      def destroy(object)
-        object.destroy!
-      end
+        def build(args = {}, &block)
+          record.new(args, &block)
+        end
 
-      def transaction(&block)
-        record.transaction(&block)
-      end
+        def duplicate(object, args = {})
+          object.dup.tap do |new_object|
+            new_object.assign_attributes(args) if args.present?
+            yield(new_object)                  if block_given?
+          end
+        end
 
-      private
+        def persist(object)
+          object.save!
+        end
 
-      def query_columns
-        columns = (record.column_names - [:created_at, :updated_at])
-        columns.map { |column_name| "#{record.table_name}.#{column_name}" }
+        def destroy(object)
+          object.destroy!
+        end
+
+        def transaction(&block)
+          record.transaction(&block)
+        end
+
+        private
+
+        def query_columns
+          columns = (record.column_names - [:created_at, :updated_at])
+          columns.map { |column_name| "#{record.table_name}.#{column_name}" }
+        end
       end
     end
   end

--- a/lib/railjet/repository/generic.rb
+++ b/lib/railjet/repository/generic.rb
@@ -9,10 +9,6 @@ module Railjet
         attr_accessor :type
       end
 
-      def self.[](dao)
-        new(dao)
-      end
-
       def initialize(dao)
         @dao  = dao
         @type = self.class.type
@@ -22,6 +18,8 @@ module Railjet
         define_dao_accessor(@type, @dao)
         define_type_accessor(klass, @type)
         define_initializer(klass)
+
+        klass.send :include, self.class::RepositoryMethods
       end
 
       private

--- a/lib/railjet/repository/redis.rb
+++ b/lib/railjet/repository/redis.rb
@@ -5,24 +5,26 @@ module Railjet
     class Redis < Generic
       self.type = :redis
 
-      def get(key)
-        redis.get(key)
-      end
+      module RepositoryMethods
+        def get(key)
+          redis.get(key)
+        end
 
-      def set(key, val)
-        redis.set(key, val)
-      end
+        def set(key, val)
+          redis.set(key, val)
+        end
 
-      def exists?(key)
-        redis.exists(key)
-      end
+        def exists?(key)
+          redis.exists(key)
+        end
 
-      def transaction(&block)
-        redis.multi(&block)
-      end
+        def transaction(&block)
+          redis.multi(&block)
+        end
 
-      def pipeline(&block)
-        redis.pipelined(&block)
+        def pipeline(&block)
+          redis.pipelined(&block)
+        end
       end
     end
   end

--- a/spec/railjet/repository_spec.rb
+++ b/spec/railjet/repository_spec.rb
@@ -49,4 +49,12 @@ describe Railjet::Repository do
       end
     end
   end
+  
+  describe "initialized repo" do
+    subject(:repo) { DummyOneRepository.new(registry) }
+    
+    it "responds to methods from included repo" do
+      expect(repo).to respond_to :persist
+    end
+  end
 end


### PR DESCRIPTION
Methods that are on the Module subclass are not injected into the repo when module is included. The fix is to wrap repo methods inside a module, and manually inject that module.