### PR TITLE
Fix setting DAO through Registry

### DIFF
--- a/lib/railjet/repository.rb
+++ b/lib/railjet/repository.rb
@@ -32,7 +32,7 @@ module Railjet
       ivar = "@#{repository.type}"
       dao  = kwargs[repository.type]
 
-      instance_variable_set(ivar, repository.new(registry, dao: dao))
+      instance_variable_set(ivar, repository.new(registry, :"#{repository.type}" => dao))
       self.class.send :attr_reader, repository.type
     end
   end

--- a/lib/railjet/repository/generic.rb
+++ b/lib/railjet/repository/generic.rb
@@ -9,7 +9,7 @@ module Railjet
         attr_accessor :type
       end
 
-      def initialize(dao)
+      def initialize(dao = nil)
         @dao  = dao
         @type = self.class.type
       end

--- a/spec/railjet/integration/repository_spec.rb
+++ b/spec/railjet/integration/repository_spec.rb
@@ -122,4 +122,36 @@ describe "Repository & Registry" do
       expect(registry.tasks).to be_instance_of DummyTaskRepository
     end
   end
+  
+  describe "DAO not specified in repository" do
+    class DummyEmployeeRepository
+      include Railjet::Repository
+      
+      class RedisRepository
+        include Railjet::Repository::Redis[]
+      end
+    end
+    
+    context "not set also in registry" do
+      before do
+        registry.register(:employee, DummyEmployeeRepository)
+      end
+      
+      it "raise exception when repo is called for first time" do
+        expect { registry.employees }.to raise_exception ArgumentError, /Your repository DummyEmployeeRepository::RedisRepository need a DAO/
+      end
+    end
+    
+    context "set in registry" do
+      let(:redis_dao) { double }
+
+      before do
+        registry.register(:employee, DummyEmployeeRepository, redis: redis_dao)
+      end
+      
+      it "calls repo without errors" do
+        expect { registry.employees }.not_to raise_exception
+      end
+    end
+  end
 end

--- a/spec/railjet/integration/repository_spec.rb
+++ b/spec/railjet/integration/repository_spec.rb
@@ -128,7 +128,7 @@ describe "Repository & Registry" do
       include Railjet::Repository
       
       class RedisRepository
-        include Railjet::Repository::Redis[]
+        include Railjet::Repository::Redis.new
       end
     end
     

--- a/spec/railjet/registry_spec.rb
+++ b/spec/railjet/registry_spec.rb
@@ -18,8 +18,21 @@ describe Railjet::Repository::Registry do
     end
 
     it "initializes repository with given models" do
-      expect(DummyRepository).to receive(:new).with(app_registry)
+      expect(DummyRepository).to receive(:new).with(app_registry, {})
       app_registry.users
+    end
+    
+    context "with different DAO" do
+      let(:other_dao) { double }
+      
+      before do
+        app_registry.register(:user, DummyRepository, some_other_dao: other_dao)
+      end
+      
+      it "initialized repository with overriden DAO" do
+        expect(DummyRepository).to receive(:new).with(app_registry, some_other_dao: other_dao)
+        app_registry.users
+      end
     end
   end
 


### PR DESCRIPTION
* scenario 1:
```ruby
# set in repo
class FooRepository
  include Railjet::Repository

  class ActiveRecordRepository
    include Railjet::Repository::ActiveRecord["Foo"]
  end
end

# use as is in registry
AppRegistry.register(:foo, FooRepository
```

* scenario 2
```ruby
# set in repo
class FooRepository
  include Railjet::Repository

  class ActiveRecordRepository
    include Railjet::Repository::ActiveRecord["Foo"]
  end
end

# but override in registry (eg. only in one of the engines)
AppRegistry.register(:foo, FooRepository, record: FooOnSteroids)
```

* scenario 3 (possible sometimes, also makes transition easier)
```ruby
# don't set in repo, old version looked almost exactly like this (#new has to be added)
class FooRepository
  include Railjet::Repository

  class ActiveRecordRepository
    include Railjet::Repository::ActiveRecord.new
  end
end

# set in registry for the first time
AppRegistry.register(:foo, FooRepository, record: Foo)
```

In scenario 3, if I wouldn't specify it registry, there would be meaninful exception thrown

