### PR TITLE
Fix on-the-fly Context writer

### DIFF
--- a/lib/railjet/context.rb
+++ b/lib/railjet/context.rb
@@ -26,7 +26,7 @@ module Railjet
 
     def define_accessor(name, value)
       instance_variable_set("@#{name}", value)
-      self.class.send(:attr_reader, name)
+      define_singleton_method(name) { instance_variable_get(:"@#{name}") }
     end
   end
 end

--- a/spec/railjet/context_spec.rb
+++ b/spec/railjet/context_spec.rb
@@ -28,6 +28,14 @@ describe Railjet::Context do
     expect { context.foo = "foo" }.to raise_exception(NoMethodError)
   end
 
+  it "does not share writers between instances" do
+    context.foo = "bar"
+    new_context = DummyAppContext.new(current_employee: current_employee, repository: repository)
+
+    expect { new_context.foo = "foo" }.not_to raise_error(NoMethodError)
+    expect(new_context.foo).to eq "foo"
+  end
+
   it "does not allow editing values" do
     expect { context.current_employee = "something else" }.to raise_exception(NoMethodError)
   end


### PR DESCRIPTION
currently if I do:

```ruby
c1 = Railjet::Context.new
c1.foo = "foo"
c2 = Railjet::Context.new
c2.foo = "bar"
```

I will get NoMethodError. It happens because writer method is created on a class, not an an instance.