### PR TITLE
Presenters 2.0 

### DIFF
--- a/lib/railjet.rb
+++ b/lib/railjet.rb
@@ -44,6 +44,7 @@ require "railjet/policy"
 require "railjet/composed_policy"
 require "railjet/use_case"
 require "railjet/presenter"
+require "railjet/presenter_context"
 
 require "railjet/repository/registry"
 require "railjet/repository"

--- a/lib/railjet/presenter.rb
+++ b/lib/railjet/presenter.rb
@@ -8,25 +8,29 @@ module Railjet
       @object = object
     end
 
+    attr_reader :object
+
     def as_json(*)
       raise NotImplementedError
     end
 
     module ClassMethods
       def present_collection(objects)
-        objects.map { |o| new(o) }
+        objects.map { |o| present(o) }
       end
 
-      private
+      def present(object)
+        new(object)
+      end
 
-      def present(name)
-        define_method(name) { instance_variable_get(:@object) }
-        private name
+      def object(name)
+        alias_method name, :object
       end
     end
 
     module WithContext
       extend ActiveSupport::Concern
+      include Railjet::Presenter
 
       included do
         attr_reader :context
@@ -40,7 +44,15 @@ module Railjet
 
       module ClassMethods
         def present_collection(context, objects)
-          objects.map { |o| new(context, o) }
+          objects.map { |o| present(context, o) }
+        end
+
+        def present(context, object)
+          new(context, object)
+        end
+
+        def context(*context_members)
+          delegate *context_members, to: :context
         end
       end
 

--- a/lib/railjet/presenter_context.rb
+++ b/lib/railjet/presenter_context.rb
@@ -1,0 +1,14 @@
+module Railjet
+  class PresenterContext < SimpleDelegator
+    attr_reader :view
+
+    def initialize(context, view_context)
+      super(context)
+      @view = view_context
+    end
+
+    def repository
+      raise NoMethodError, "Acessing Repository from Presenter is a no-no 🙅‍♂️"
+    end
+  end
+end

--- a/spec/railjet/context_spec.rb
+++ b/spec/railjet/context_spec.rb
@@ -32,7 +32,7 @@ describe Railjet::Context do
     context.foo = "bar"
     new_context = DummyAppContext.new(current_employee: current_employee, repository: repository)
 
-    expect { new_context.foo = "foo" }.not_to raise_error(NoMethodError)
+    expect { new_context.foo = "foo" }.not_to raise_error
     expect(new_context.foo).to eq "foo"
   end
 

--- a/spec/railjet/presenter_context_spec.rb
+++ b/spec/railjet/presenter_context_spec.rb
@@ -1,0 +1,18 @@
+require "railjet/presenter_context"
+
+describe Railjet::PresenterContext do
+  let(:repository)   { double("repository") }
+  let(:context)      { double("context", repository: repository) }
+  let(:view_context) { double("view_context") }
+
+  subject(:presenter_context) { described_class.new(context, view_context) }
+
+  it "gives access to view context" do
+    expect(presenter_context.view).to eq view_context
+  end
+
+  it "removes repository" do
+    expect { presenter_context.repository }.to raise_error NoMethodError
+    expect(context.repository).to eq repository
+  end
+end

--- a/spec/railjet/presenter_spec.rb
+++ b/spec/railjet/presenter_spec.rb
@@ -2,7 +2,7 @@ require "railjet/presenter"
 
 class DummyClientPresenter
   include Railjet::Presenter
-  present :client
+  object :client
 
   def as_json(*)
     {
@@ -13,16 +13,16 @@ class DummyClientPresenter
 end
 
 class DummyEmployeePresenter
-  include Railjet::Presenter
   include Railjet::Presenter::WithContext
-  present :employee
+  context :current_ability
+  object  :employee
 
   def as_json(*)
     {
       id:   employee.id,
       name: employee.display_name,
 
-      can_edit_events: context.current_ability.can_edit_events?
+      can_edit_events: current_ability.can_edit_events?
     }
   end
 end
@@ -44,7 +44,7 @@ describe Railjet::Presenter do
   let(:client_two) { double(id: 2, display_name: "Anna Doe") }
 
   describe "::present" do
-    subject(:presenter) { DummyClientPresenter.new(client_one) }
+    subject(:presenter) { DummyClientPresenter.present(client_one) }
 
     it "creates an accessor for @object ivar" do
       expect(presenter.as_json).to eq({ id: 1, name: "John Doe" })
@@ -68,7 +68,7 @@ describe Railjet::Presenter::WithContext do
   let(:current_ability) { double(can_edit_events?: true) }
 
   describe "::initialize" do
-    let(:presenter) { DummyEmployeePresenter.new(context, employee_one) }
+    let(:presenter) { DummyEmployeePresenter.present(context, employee_one) }
 
     it "can be initialized with context" do
       expect(presenter.as_json).to eq({ id: 1, name: "John Doe", can_edit_events: true })


### PR DESCRIPTION
After discussion last week with @loed-idzinga about Presenters, we concluded that Presenter and a Factory should have cohesive interface. 

Until now they didn't - 
* `Presenter::Factory` has `::present_collection` and `::present` for single objects
* `Presenter` also has `::present_collection` but use `::present` as a macro to create accessor method - `present :event` 

On the other hand, in `Policy` we already have similar macro and we call it `::object`. 

This PR switches it all up to have nice, common interface across railjet 😉

Also:
* now when you include `Presenter::WithContext`, then `Presenter` is also included, no need to include 2 mixins
* `PresenterContext` extracted out of OnsAgenda
