### PR TITLE
Add find_by_id to active_record repository

### DIFF
--- a/lib/railjet/repository/active_record.rb
+++ b/lib/railjet/repository/active_record.rb
@@ -10,6 +10,10 @@ module Railjet
           record.all
         end
 
+        def find_by_id(id)
+          record.find(id)
+        end
+
         def find_by_ids(ids)
           record.where(id: ids)
         end


### PR DESCRIPTION
Fixes #39

A lot of implemented repositories have added a find_by_id which is such a simple function that adding it to Railjet itself makes sense.